### PR TITLE
Bulk delete checkpoints

### DIFF
--- a/docs/docs/cli/checkpoint/delete.mdx
+++ b/docs/docs/cli/checkpoint/delete.mdx
@@ -3,7 +3,7 @@
 ## Usage
 
 ```bash
-pf checkpoint delete [OPTIONS] CHECKPOINT_ID
+pf checkpoint delete [OPTIONS] CHECKPOINT_IDS
 ```
 
 ## Summary
@@ -22,7 +22,7 @@ Checkpoints that are uploaded or generated from training jobs are physically del
 
 | Argument | Type | Summary | Default | Required | 
 |----------|------|---------|---------|----------|
-| **`checkpoint_id`** | UUID | ID of checkpoint to delete. | - | ✅ |
+| **`checkpoint_ids`** | UUID | IDs of checkpoint to delete. When multiple IDs are provided, all those checkpoints are deleted. | - | ✅ |
 
 ## Options
 

--- a/docs/docs/cli/checkpoint/delete.mdx
+++ b/docs/docs/cli/checkpoint/delete.mdx
@@ -22,7 +22,7 @@ Checkpoints that are uploaded or generated from training jobs are physically del
 
 | Argument | Type | Summary | Default | Required | 
 |----------|------|---------|---------|----------|
-| **`checkpoint_ids`** | UUID | IDs of checkpoint to delete. When multiple IDs are provided, all those checkpoints are deleted. | - | ✅ |
+| **`checkpoint_ids`** | UUID | IDs of checkpoint to delete. When multiple IDs are provided in a space-separated string format, all corresponding checkpoints will be deleted. | - | ✅ |
 
 ## Options
 

--- a/periflow/cli/checkpoint.py
+++ b/periflow/cli/checkpoint.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 import typer
@@ -364,7 +364,13 @@ def create(
 
 @app.command()
 def delete(
-    checkpoint_id: UUID = typer.Argument(..., help="ID of checkpoint to delete."),
+    checkpoint_ids: List[UUID] = typer.Argument(
+        ...,
+        help=(
+            "IDs of checkpoint to delete. "
+            "When multiple IDs are provided, all those checkpoints are deleted."
+        ),
+    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -383,14 +389,23 @@ def delete(
     :::
 
     """
+    targets_str = ""
+    for checkpoint_id in checkpoint_ids:
+        targets_str += str(checkpoint_id)
+        targets_str += "\n"
+
     if not force:
-        do_delete = typer.confirm("Are you sure to delete checkpoint?")
+        do_delete = typer.confirm(
+            f"Following checkpoints will be deleted:\n\n{targets_str}\n"
+            "Are your sure to delete these?"
+        )
         if not do_delete:
             raise typer.Abort()
 
-    CheckpointAPI.delete(id=checkpoint_id)
+    for checkpoint_id in checkpoint_ids:
+        CheckpointAPI.delete(id=checkpoint_id)
 
-    typer.secho("Checkpoint is deleted successfully!", fg=typer.colors.BLUE)
+    typer.secho("Checkpoints are deleted successfully!", fg=typer.colors.BLUE)
 
 
 @app.command()

--- a/periflow/cli/checkpoint.py
+++ b/periflow/cli/checkpoint.py
@@ -368,7 +368,8 @@ def delete(
         ...,
         help=(
             "IDs of checkpoint to delete. "
-            "When multiple IDs are provided, all those checkpoints are deleted."
+            "When multiple IDs are provided in a space-separated string format, all "
+            "corresponding checkpoints will be deleted."
         ),
     ),
     force: bool = typer.Option(


### PR DESCRIPTION
# PR Description

## Summary

Now `pf checkpoint delete` gets an argument of checkpoint IDs, which means that it allows multiple IDs of checkpoints to delete.

## Motivation and Context

It is bothersome to delete multiple checkpoints one by one.

## Type of Change

- Breaking change
- Documentation update
