### PR TITLE
Allow gpt-neox-hf model type

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Check out [PeriFlow Client Docs](https://docs.periflow.ai/) to learn more.
 pip install periflow-client
 ```
 
+If you have a Hugging Face checkpoint and want to convert it to a PeriFlow-compatible format, you need to install the package with the necessary machine learing library (`mllib`) dependencies. In this case, install the package with the following command:
+
+```sh
+pip install periflow-client[mllib]
+```
+
 ## Examples
 
 This example shows how to create a deployment and send a completion API request to the created deployment with Python SDK.

--- a/docs/docs/cli/checkpoint/convert.mdx
+++ b/docs/docs/cli/checkpoint/convert.mdx
@@ -10,11 +10,10 @@ pf checkpoint convert [OPTIONS]
 
 Convert huggingface's model checkpoint to PeriFlow format.
 
-::: info
-When a checkpoint has Hugging Face format, it cannot be served right away. Instead,
-it needs to be converted to PeriFlow format for serving. From the orignal checkpoint,
-it is copied and converted to Periflow format checkpoint(*.h5).
-:::
+When a checkpoint is in the Hugging Face format, it cannot be directly served;
+rather, it requires conversion to the PeriFlow format for serving. The conversion
+process involves copying the original checkpoint and transforming it into a
+checkpoint in the PeriFlow format (*.h5).
 
 :::caution
 The `pf checkpoint convert` is available only when the package is installed with

--- a/docs/docs/cli/installation.mdx
+++ b/docs/docs/cli/installation.mdx
@@ -21,6 +21,14 @@ You can check the release history at [PyPI](https://pypi.org/project/periflow-cl
 You can update the package with:
 
 ```bash
-pip install periflow-client -U --no-cache-dir
+pip install periflow-client -U
+```
+:::
+
+:::info
+If you have a Hugging Face checkpoint and want to convert it to a PeriFlow-compatible format, you need to install the package with the necessary machine learing library (`mllib`) dependencies. In this case, install the package with the following command:
+
+```sh
+pip install periflow-client[mllib]
 ```
 :::

--- a/periflow/cli/checkpoint.py
+++ b/periflow/cli/checkpoint.py
@@ -676,11 +676,10 @@ def convert(
 ):
     """Convert huggingface's model checkpoint to PeriFlow format.
 
-    ::: info
-    When a checkpoint has Hugging Face format, it cannot be served right away. Instead,
-    it needs to be converted to PeriFlow format for serving. From the orignal checkpoint,
-    it is copied and converted to Periflow format checkpoint(*.h5).
-    :::
+    When a checkpoint is in the Hugging Face format, it cannot be directly served;
+    rather, it requires conversion to the PeriFlow format for serving. The conversion
+    process involves copying the original checkpoint and transforming it into a
+    checkpoint in the PeriFlow format (*.h5).
 
     :::caution
     The `pf checkpoint convert` is available only when the package is installed with

--- a/periflow/schema/resource/v1/attributes.py
+++ b/periflow/schema/resource/v1/attributes.py
@@ -87,6 +87,19 @@ class V1GPTNeoXAttributes(V1CommonAttributes):
     eos_token: int
 
 
+class V1GPTNeoXHFAttributes(V1CommonAttributes):
+    """V1 GPT-NeoX HF attributes schema."""
+
+    model_type: Literal["gpt-neox-hf"]
+    head_size: int
+    rotary_dim: int
+    num_heads: int
+    num_layers: int
+    max_length: int
+    vocab_size: int
+    eos_token: int
+
+
 class V1LlamaAttributes(V1CommonAttributes):
     """V1 LLaMA attributes schema."""
 
@@ -168,6 +181,7 @@ V1CheckpointAttributes = Annotated[
         V1GPTAttributes,
         V1GPTJAttributes,
         V1GPTNeoXAttributes,
+        V1GPTNeoXHFAttributes,
         V1LlamaAttributes,
         V1MPTAttributes,
         V1OPTAttributes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "periflow-client"
-version = "0.1.4"
+version = "0.1.5"
 description = "Client of PeriFlow, the fastest generative AI serving available."
 license = "Apache-2.0"
 authors = ["PeriFlow teams <eng@friendli.ai>"]


### PR DESCRIPTION
# PR Description

## Summary

This PR makes `pf checkpoint create` and `pf checkpoint upload` allow to get "gpt-neox-hf" model type.

## Type of Change

- New feature
- Breaking change
- Documentation update
