### PR TITLE
Dependency injection module to loosen coupling to service URLs

### DIFF
--- a/periflow/__init__.py
+++ b/periflow/__init__.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import os
 
+from periflow.di.injector import set_default_modules
+from periflow.di.modules import default_modules
 from periflow.schema.api.v1.completion import V1CompletionOptions
 from periflow.sdk.api.completion import Completion
 from periflow.sdk.init import init
@@ -17,6 +19,7 @@ api_key = os.environ.get("PERIFLOW_API_KEY")
 org_id = os.environ.get("PERIFLOW_ORG_ID")
 project_id = os.environ.get("PERIFLOW_PRJ_ID")
 
+set_default_modules(default_modules)
 
 __all__ = [
     "api_key",

--- a/periflow/auth.py
+++ b/periflow/auth.py
@@ -96,11 +96,11 @@ def auto_token_refresh(
     func: Callable[..., requests.Response]
 ) -> Callable[..., requests.Response]:
     """Decorator for automatic token refresh."""
-    injector = get_injector()
-    url_provider = injector.get(URLProvider)
-
     @functools.wraps(func)
     def inner(*args, **kwargs) -> requests.Response:
+        injector = get_injector()
+        url_provider = injector.get(URLProvider)
+
         resp = func(*args, **kwargs)
         if resp.status_code in (401, 403):
             refresh_token = get_token(TokenType.REFRESH)

--- a/periflow/auth.py
+++ b/periflow/auth.py
@@ -96,6 +96,7 @@ def auto_token_refresh(
     func: Callable[..., requests.Response]
 ) -> Callable[..., requests.Response]:
     """Decorator for automatic token refresh."""
+
     @functools.wraps(func)
     def inner(*args, **kwargs) -> requests.Response:
         injector = get_injector()

--- a/periflow/cli/deployment.py
+++ b/periflow/cli/deployment.py
@@ -404,6 +404,10 @@ def log(
 ):
     """Shows deployments log."""
     logs = DeploymentAPI.get_logs(id=deployment_id, replica_index=replica_index)
+
+    if len(logs) == 0:
+        secho_error_and_exit("Logs are not found yet.")
+
     for line in logs:
         typer.echo(line["data"])
 

--- a/periflow/client/checkpoint.py
+++ b/periflow/client/checkpoint.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from requests.models import Response
 
 from periflow.client.base import Client, UploadableClient, safe_request
-from periflow.utils.url import get_mr_uri
 
 
 class CheckpointClient(Client[UUID]):
@@ -20,7 +19,7 @@ class CheckpointClient(Client[UUID]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_mr_uri("models/"))
+        return Template(self.url_provider.get_mr_uri("models/"))
 
     def get_checkpoint(self, checkpoint_id: UUID) -> Dict[str, Any]:
         """Get a checkpoint info."""
@@ -57,7 +56,7 @@ class CheckpointFormClient(UploadableClient[UUID]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_mr_uri("model_forms/"))
+        return Template(self.url_provider.get_mr_uri("model_forms/"))
 
     def update_checkpoint_files(
         self,

--- a/periflow/client/credential.py
+++ b/periflow/client/credential.py
@@ -12,7 +12,6 @@ from uuid import UUID
 from periflow.client.base import Client, safe_request
 from periflow.enums import CredType
 from periflow.utils.maps import cred_type_map
-from periflow.utils.url import get_auth_uri, get_training_uri
 
 
 class CredentialClient(Client[UUID]):
@@ -21,7 +20,7 @@ class CredentialClient(Client[UUID]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("credential"))
+        return Template(self.url_provider.get_auth_uri("credential"))
 
     def get_credential(self, credential_id: UUID) -> Dict[str, Any]:
         """Get a credential info."""
@@ -64,7 +63,7 @@ class CredentialTypeClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_training_uri("credential_type/"))
+        return Template(self.url_provider.get_training_uri("credential_type/"))
 
     def get_schema_by_type(self, cred_type: CredType) -> Optional[Dict[str, Any]]:
         """Get a credential JSON schema."""

--- a/periflow/client/deployment.py
+++ b/periflow/client/deployment.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, List, Optional
 from requests import Response
 
 from periflow.client.base import Client, ProjectRequestMixin, safe_request
-from periflow.utils.url import get_serving_uri
 
 
 # TODO (ym): Replace this with periflow.utils.request.paginated_get after unifying schema
@@ -44,7 +43,7 @@ class DeploymentClient(Client[str]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("deployment/"))
+        return Template(self.url_provider.get_serving_uri("deployment/"))
 
     def get_deployment(self, deployment_id: str) -> Dict[str, Any]:
         """Get a deployment info."""
@@ -106,7 +105,9 @@ class DeploymentLogClient(Client[str]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("deployment/$deployment_id/log/"))
+        return Template(
+            self.url_provider.get_serving_uri("deployment/$deployment_id/log/")
+        )
 
     def get_deployment_logs(
         self, deployment_id: str, replica_index: int
@@ -127,7 +128,9 @@ class DeploymentMetricsClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("deployment/$deployment_id/metrics/"))
+        return Template(
+            self.url_provider.get_serving_uri("deployment/$deployment_id/metrics/")
+        )
 
     def get_metrics(self, deployment_id: str, time_window: int) -> Dict[str, Any]:
         """Get metrics from a deployment."""
@@ -144,7 +147,9 @@ class DeploymentEventClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("deployment/$deployment_id/event/"))
+        return Template(
+            self.url_provider.get_serving_uri("deployment/$deployment_id/event/")
+        )
 
     def get_events(self, deployment_id: str) -> List[Dict[str, Any]]:
         """Get deployment events."""
@@ -161,7 +166,11 @@ class DeploymentReqRespClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("deployment/$deployment_id/req_resp/download/"))
+        return Template(
+            self.url_provider.get_serving_uri(
+                "deployment/$deployment_id/req_resp/download/"
+            )
+        )
 
     def get_download_urls(
         self, deployment_id: str, start: datetime, end: datetime
@@ -189,7 +198,9 @@ class PFSProjectUsageClient(Client[str], ProjectRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("usage/project/$project_id/duration"))
+        return Template(
+            self.url_provider.get_serving_uri("usage/project/$project_id/duration")
+        )
 
     def get_usage(
         self,
@@ -214,7 +225,7 @@ class PFSVMClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_serving_uri("vm/"))
+        return Template(self.url_provider.get_serving_uri("vm/"))
 
     def list_vms(self) -> List[Dict[str, Any]]:
         """List all VM info."""

--- a/periflow/client/file.py
+++ b/periflow/client/file.py
@@ -15,7 +15,6 @@ from periflow.client.base import (
     UserRequestMixin,
     safe_request,
 )
-from periflow.utils.url import get_mr_uri
 
 
 class FileClient(Client[UUID]):
@@ -24,7 +23,7 @@ class FileClient(Client[UUID]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_mr_uri("files/"))
+        return Template(self.url_provider.get_mr_uri("files/"))
 
     def get_misc_file_upload_url(self, misc_file_id: UUID) -> str:
         """Get an URL to upload file.
@@ -87,7 +86,9 @@ class GroupProjectFileClient(
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_mr_uri("orgs/$group_id/prjs/$project_id/files/"))
+        return Template(
+            self.url_provider.get_mr_uri("orgs/$group_id/prjs/$project_id/files/")
+        )
 
     def create_misc_file(self, file_info: Dict[str, Any]) -> Dict[str, Any]:
         """Request to create a misc file.

--- a/periflow/client/group.py
+++ b/periflow/client/group.py
@@ -21,7 +21,6 @@ from periflow.client.base import (
 )
 from periflow.enums import CheckpointCategory, StorageType
 from periflow.utils.request import paginated_get
-from periflow.utils.url import get_auth_uri, get_mr_uri
 
 
 class GroupClient(Client):
@@ -30,7 +29,7 @@ class GroupClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_group"))
+        return Template(self.url_provider.get_auth_uri("pf_group"))
 
     def create_group(self, name: str) -> Dict[str, Any]:
         """Create a new organization."""
@@ -75,7 +74,9 @@ class GroupProjectClient(Client, GroupRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_group/$pf_group_id/pf_project"))
+        return Template(
+            self.url_provider.get_auth_uri("pf_group/$pf_group_id/pf_project")
+        )
 
     def create_project(self, name: str) -> Dict[str, Any]:
         """Create a new project in the organization."""
@@ -107,7 +108,9 @@ class GroupProjectCheckpointClient(
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_mr_uri("orgs/$group_id/prjs/$project_id/models/"))
+        return Template(
+            self.url_provider.get_mr_uri("orgs/$group_id/prjs/$project_id/models/")
+        )
 
     def list_checkpoints(
         self, category: Optional[CheckpointCategory], limit: int, deleted: bool

--- a/periflow/client/project.py
+++ b/periflow/client/project.py
@@ -17,7 +17,6 @@ from periflow.enums import CredType
 from periflow.utils.format import secho_error_and_exit
 from periflow.utils.maps import cred_type_map
 from periflow.utils.request import paginated_get
-from periflow.utils.url import get_auth_uri
 
 
 def find_project_id(projects: List[Dict[str, Any]], project_name: str) -> UUID:
@@ -34,7 +33,7 @@ class ProjectClient(Client[UUID]):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_project"))
+        return Template(self.url_provider.get_auth_uri("pf_project"))
 
     def get_project(self, pf_project_id: UUID) -> Dict[str, Any]:
         """Get project info."""
@@ -76,7 +75,9 @@ class ProjectCredentialClient(Client, ProjectRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_project/$project_id/credential"))
+        return Template(
+            self.url_provider.get_auth_uri("pf_project/$project_id/credential")
+        )
 
     def list_credentials(
         self, cred_type: Optional[CredType] = None

--- a/periflow/client/user.py
+++ b/periflow/client/user.py
@@ -16,7 +16,6 @@ from periflow.client.base import (
 )
 from periflow.enums import GroupRole, ProjectRole
 from periflow.utils.request import paginated_get
-from periflow.utils.url import get_auth_uri
 
 
 class UserMFAClient(Client):
@@ -25,7 +24,7 @@ class UserMFAClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("mfa"))
+        return Template(self.url_provider.get_auth_uri("mfa"))
 
     def initiate_mfa(self, mfa_type: str, mfa_token: str) -> None:
         """Authenticate by MFA token."""
@@ -40,7 +39,7 @@ class UserSignUpClient(Client):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_user/self_signup"))
+        return Template(self.url_provider.get_auth_uri("pf_user/self_signup"))
 
     def verify(self, token: str, key: str) -> None:
         """Verify the email account with the token to sign up."""
@@ -60,7 +59,7 @@ class UserClient(Client, UserRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_user"))
+        return Template(self.url_provider.get_auth_uri("pf_user"))
 
     def change_password(self, old_password: str, new_password: str) -> None:
         """Change password."""
@@ -138,7 +137,7 @@ class UserGroupClient(Client, UserRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_user/$pf_user_id/pf_group"))
+        return Template(self.url_provider.get_auth_uri("pf_user/$pf_user_id/pf_group"))
 
     def get_group_info(self) -> Dict[str, Any]:
         """Get organization info where user belongs to."""
@@ -159,7 +158,9 @@ class UserGroupProjectClient(Client, UserRequestMixin, GroupRequestMixin):
     def url_path(self) -> Template:
         """Get an URL path."""
         return Template(
-            get_auth_uri("pf_user/$pf_user_id/pf_group/$pf_group_id/pf_project")
+            self.url_provider.get_auth_uri(
+                "pf_user/$pf_user_id/pf_group/$pf_group_id/pf_project"
+            )
         )
 
     def list_projects(self) -> List[Dict[str, Any]]:
@@ -181,7 +182,7 @@ class UserAccessKeyClient(Client, UserRequestMixin):
     @property
     def url_path(self) -> Template:
         """Get an URL path."""
-        return Template(get_auth_uri("pf_user"))
+        return Template(self.url_provider.get_auth_uri("pf_user"))
 
     def create_access_key(self, name: str) -> Dict[str, Any]:
         """Create a new access key."""

--- a/periflow/di/__init__.py
+++ b/periflow/di/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2022-present, FriendliAI Inc. All rights reserved.
+
+"""Dependency Injection Modules."""

--- a/periflow/di/injector.py
+++ b/periflow/di/injector.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2022-present, FriendliAI Inc. All rights reserved.
+
+"""PeriFlow Client Dependency Injector."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Callable, Iterable, Iterator, Optional, Type, Union
+
+from injector import Binder, Injector, Module
+
+_InstallableModuleType = Union[Callable[[Binder], None], Module, Type[Module]]
+
+default_injector = Injector()
+test_injector = None
+
+
+def get_injector() -> Injector:
+    """Gets injector for DI."""
+    return test_injector or default_injector
+
+
+@contextmanager
+def patch_modules(
+    modules: Union[
+        _InstallableModuleType, Iterable[_InstallableModuleType], None
+    ] = None,
+    override_defaults: bool = False,
+) -> Iterator[None]:
+    """Patches injector modules."""
+    global test_injector  # pylint: disable=global-statement
+    old_injector = test_injector
+
+    parent_injector: Optional[Injector] = None
+    if old_injector:
+        parent_injector = old_injector
+    elif override_defaults:
+        parent_injector = default_injector
+    else:
+        parent_injector = None
+
+    test_injector = Injector(modules, parent=parent_injector)
+    try:
+        yield
+    finally:
+        test_injector = old_injector
+
+
+def set_default_modules(
+    modules: Union[
+        _InstallableModuleType, Iterable[_InstallableModuleType], None
+    ] = None,
+):
+    """Set default DI modules."""
+    global default_injector  # pylint: disable=global-statement
+    default_injector = Injector(modules)

--- a/periflow/di/modules.py
+++ b/periflow/di/modules.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-present, FriendliAI Inc. All rights reserved.
+
+"""Modules that configures bindings to providers."""
+
+from __future__ import annotations
+
+from injector import Binder, Module
+
+from periflow.utils.url import ProductionURLProvider, URLProvider
+
+
+class URLModule(Module):
+    """PeriFlow client module."""
+
+    def configure(self, binder: Binder) -> None:
+        """Configures bindings for clients."""
+        binder.bind(URLProvider, to=ProductionURLProvider)  # type: ignore
+
+
+default_modules = [URLModule]

--- a/periflow/di/modules.py
+++ b/periflow/di/modules.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from injector import Binder, Module
 
-from periflow.utils.url import ProductionURLProvider, URLProvider
+from periflow.utils import url
 
 
 class URLModule(Module):
@@ -14,7 +14,7 @@ class URLModule(Module):
 
     def configure(self, binder: Binder) -> None:
         """Configures bindings for clients."""
-        binder.bind(URLProvider, to=ProductionURLProvider)  # type: ignore
+        binder.bind(url.URLProvider, to=url.ProductionURLProvider)  # type: ignore
 
 
 default_modules = [URLModule]

--- a/periflow/utils/url.py
+++ b/periflow/utils/url.py
@@ -6,49 +6,7 @@ from __future__ import annotations
 
 from urllib.parse import urljoin, urlparse
 
-training_url = "https://training.periflow.ai/api/"
-training_ws_url = "wss://training-ws.periflow.ai/ws/"
 discuss_url = "https://discuss.friendli.ai/"
-registry_url = "https://modelregistry.periflow.ai/"
-serving_url = "https://serving.periflow.ai/"
-auth_url = "https://auth.periflow.ai/"
-meter_url = "https://metering.periflow.ai/"
-observatory_url = "https://observatory.periflow.ai/"
-
-
-def get_auth_uri(path: str) -> str:
-    """Get PFA URI."""
-    return urljoin(auth_url, path)
-
-
-def get_training_uri(path: str) -> str:
-    """Get PFT URI."""
-    return urljoin(training_url, path)
-
-
-def get_training_ws_uri(path: str) -> str:
-    """Get PFT websocket URI."""
-    return urljoin(training_ws_url, path)
-
-
-def get_serving_uri(path: str) -> str:
-    """Get PFS URI."""
-    return urljoin(serving_url, path)
-
-
-def get_mr_uri(path: str) -> str:
-    """Get PFR URI."""
-    return urljoin(registry_url, path)
-
-
-def get_meter_uri(path: str) -> str:
-    """Get PFM URI."""
-    return urljoin(meter_url, path)
-
-
-def get_observatory_uri(path: str) -> str:
-    """Get PFO URI."""
-    return urljoin(observatory_url, path)
 
 
 def get_baseurl(url: str) -> str:
@@ -57,3 +15,183 @@ def get_baseurl(url: str) -> str:
     scheme = parsed_url.scheme
     base = parsed_url.netloc
     return f"{scheme}://{base}/"
+
+
+class URLProvider:
+    """Service URL provider."""
+
+    @classmethod
+    def get_auth_uri(cls, path: str) -> str:
+        """Get PFA URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_training_uri(cls, path: str) -> str:
+        """Get PFT URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_training_ws_uri(cls, path: str) -> str:
+        """Get PFT websocket URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_serving_uri(cls, path: str) -> str:
+        """Get PFS URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_mr_uri(cls, path: str) -> str:
+        """Get PFR URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_meter_uri(cls, path: str) -> str:
+        """Get PFM URI."""
+        raise NotImplementedError  # pragma: no cover
+
+    @classmethod
+    def get_observatory_uri(cls, path: str) -> str:
+        """Get PFO URI."""
+        raise NotImplementedError  # pragma: no cover
+
+
+class ProductionURLProvider(URLProvider):
+    """Production service URL provider."""
+
+    training_url = "https://training.periflow.ai/api/"
+    training_ws_url = "wss://training-ws.periflow.ai/ws/"
+    registry_url = "https://modelregistry.periflow.ai/"
+    serving_url = "https://serving.periflow.ai/"
+    auth_url = "https://auth.periflow.ai/"
+    meter_url = "https://metering.periflow.ai/"
+    observatory_url = "https://observatory.periflow.ai/"
+
+    @classmethod
+    def get_auth_uri(cls, path: str) -> str:
+        """Get PFA URI."""
+        return urljoin(cls.auth_url, path)
+
+    @classmethod
+    def get_training_uri(cls, path: str) -> str:
+        """Get PFT URI."""
+        return urljoin(cls.training_url, path)
+
+    @classmethod
+    def get_training_ws_uri(cls, path: str) -> str:
+        """Get PFT websocket URI."""
+        return urljoin(cls.training_ws_url, path)
+
+    @classmethod
+    def get_serving_uri(cls, path: str) -> str:
+        """Get PFS URI."""
+        return urljoin(cls.serving_url, path)
+
+    @classmethod
+    def get_mr_uri(cls, path: str) -> str:
+        """Get PFR URI."""
+        return urljoin(cls.registry_url, path)
+
+    @classmethod
+    def get_meter_uri(cls, path: str) -> str:
+        """Get PFM URI."""
+        return urljoin(cls.meter_url, path)
+
+    @classmethod
+    def get_observatory_uri(cls, path: str) -> str:
+        """Get PFO URI."""
+        return urljoin(cls.observatory_url, path)
+
+
+class StagingURLProvider(URLProvider):
+    """Staging service URL provider."""
+
+    training_url = "https://api-staging.periflow.ai/api/"
+    training_ws_url = "wss://api-ws-staging.periflow.ai/ws/"
+    registry_url = "https://pfmodelregistry-staging.periflow.ai/"
+    serving_url = "https://pfs-staging.periflow.ai/"
+    auth_url = "https://pfauth-staging.periflow.ai/"
+    meter_url = "https://pfmeter-staging.periflow.ai/"
+    observatory_url = "https://pfo-staging.periflow.ai/"
+
+    @classmethod
+    def get_auth_uri(cls, path: str) -> str:
+        """Get PFA URI."""
+        return urljoin(cls.auth_url, path)
+
+    @classmethod
+    def get_training_uri(cls, path: str) -> str:
+        """Get PFT URI."""
+        return urljoin(cls.training_url, path)
+
+    @classmethod
+    def get_training_ws_uri(cls, path: str) -> str:
+        """Get PFT websocket URI."""
+        return urljoin(cls.training_ws_url, path)
+
+    @classmethod
+    def get_serving_uri(cls, path: str) -> str:
+        """Get PFS URI."""
+        return urljoin(cls.serving_url, path)
+
+    @classmethod
+    def get_mr_uri(cls, path: str) -> str:
+        """Get PFR URI."""
+        return urljoin(cls.registry_url, path)
+
+    @classmethod
+    def get_meter_uri(cls, path: str) -> str:
+        """Get PFM URI."""
+        return urljoin(cls.meter_url, path)
+
+    @classmethod
+    def get_observatory_uri(cls, path: str) -> str:
+        """Get PFO URI."""
+        return urljoin(cls.observatory_url, path)
+
+
+class DevURLProvider(URLProvider):
+    """Dev service URL provider."""
+
+    training_url = "https://api-dev.periflow.ai/api/"
+    training_ws_url = "wss://api-ws-dev.periflow.ai/ws/"
+    registry_url = "https://pfmodelregistry-dev.periflow.ai/"
+    serving_url = "https://pfs-dev.periflow.ai/"
+    auth_url = "https://pfauth-dev.periflow.ai/"
+    meter_url = "https://pfmeter-dev.periflow.ai/"
+    observatory_url = "https://pfo-dev.periflow.ai/"
+
+    @classmethod
+    def get_auth_uri(cls, path: str) -> str:
+        """Get PFA URI."""
+        return urljoin(cls.auth_url, path)
+
+    @classmethod
+    def get_training_uri(cls, path: str) -> str:
+        """Get PFT URI."""
+        return urljoin(cls.training_url, path)
+
+    @classmethod
+    def get_training_ws_uri(cls, path: str) -> str:
+        """Get PFT websocket URI."""
+        return urljoin(cls.training_ws_url, path)
+
+    @classmethod
+    def get_serving_uri(cls, path: str) -> str:
+        """Get PFS URI."""
+        return urljoin(cls.serving_url, path)
+
+    @classmethod
+    def get_mr_uri(cls, path: str) -> str:
+        """Get PFR URI."""
+        return urljoin(cls.registry_url, path)
+
+    @classmethod
+    def get_meter_uri(cls, path: str) -> str:
+        """Get PFM URI."""
+        return urljoin(cls.meter_url, path)
+
+    @classmethod
+    def get_observatory_uri(cls, path: str) -> str:
+        """Get PFO URI."""
+        return urljoin(cls.observatory_url, path)

--- a/periflow/utils/url.py
+++ b/periflow/utils/url.py
@@ -106,13 +106,13 @@ class ProductionURLProvider(URLProvider):
 class StagingURLProvider(URLProvider):
     """Staging service URL provider."""
 
-    training_url = "https://api-staging.periflow.ai/api/"
-    training_ws_url = "wss://api-ws-staging.periflow.ai/ws/"
-    registry_url = "https://pfmodelregistry-staging.periflow.ai/"
-    serving_url = "https://pfs-staging.periflow.ai/"
-    auth_url = "https://pfauth-staging.periflow.ai/"
-    meter_url = "https://pfmeter-staging.periflow.ai/"
-    observatory_url = "https://pfo-staging.periflow.ai/"
+    training_url = "https://api-staging.friendli.ai/api/"
+    training_ws_url = "wss://api-ws-staging.friendli.ai/ws/"
+    registry_url = "https://pfmodelregistry-staging.friendli.ai/"
+    serving_url = "https://pfs-staging.friendli.ai/"
+    auth_url = "https://pfauth-staging.friendli.ai/"
+    meter_url = "https://pfmeter-staging.friendli.ai/"
+    observatory_url = "https://pfo-staging.friendli.ai/"
 
     @classmethod
     def get_auth_uri(cls, path: str) -> str:
@@ -153,13 +153,13 @@ class StagingURLProvider(URLProvider):
 class DevURLProvider(URLProvider):
     """Dev service URL provider."""
 
-    training_url = "https://api-dev.periflow.ai/api/"
-    training_ws_url = "wss://api-ws-dev.periflow.ai/ws/"
-    registry_url = "https://pfmodelregistry-dev.periflow.ai/"
-    serving_url = "https://pfs-dev.periflow.ai/"
-    auth_url = "https://pfauth-dev.periflow.ai/"
-    meter_url = "https://pfmeter-dev.periflow.ai/"
-    observatory_url = "https://pfo-dev.periflow.ai/"
+    training_url = "https://api-dev.friendli.ai/api/"
+    training_ws_url = "wss://api-ws-dev.friendli.ai/ws/"
+    registry_url = "https://pfmodelregistry-dev.friendli.ai/"
+    serving_url = "https://pfs-dev.friendli.ai/"
+    auth_url = "https://pfauth-dev.friendli.ai/"
+    meter_url = "https://pfmeter-dev.friendli.ai/"
+    observatory_url = "https://pfo-dev.friendli.ai/"
 
     @classmethod
     def get_auth_uri(cls, path: str) -> str:

--- a/periflow/utils/url.py
+++ b/periflow/utils/url.py
@@ -20,40 +20,48 @@ def get_baseurl(url: str) -> str:
 class URLProvider:
     """Service URL provider."""
 
+    training_url = ""
+    training_ws_url = ""
+    registry_url = ""
+    serving_url = ""
+    auth_url = ""
+    meter_url = ""
+    observatory_url = ""
+
     @classmethod
     def get_auth_uri(cls, path: str) -> str:
         """Get PFA URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.auth_url, path)
 
     @classmethod
     def get_training_uri(cls, path: str) -> str:
         """Get PFT URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.training_url, path)
 
     @classmethod
     def get_training_ws_uri(cls, path: str) -> str:
         """Get PFT websocket URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.training_ws_url, path)
 
     @classmethod
     def get_serving_uri(cls, path: str) -> str:
         """Get PFS URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.serving_url, path)
 
     @classmethod
     def get_mr_uri(cls, path: str) -> str:
         """Get PFR URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.registry_url, path)
 
     @classmethod
     def get_meter_uri(cls, path: str) -> str:
         """Get PFM URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.meter_url, path)
 
     @classmethod
     def get_observatory_uri(cls, path: str) -> str:
         """Get PFO URI."""
-        raise NotImplementedError  # pragma: no cover
+        return urljoin(cls.observatory_url, path)
 
 
 class ProductionURLProvider(URLProvider):
@@ -67,41 +75,6 @@ class ProductionURLProvider(URLProvider):
     meter_url = "https://metering.periflow.ai/"
     observatory_url = "https://observatory.periflow.ai/"
 
-    @classmethod
-    def get_auth_uri(cls, path: str) -> str:
-        """Get PFA URI."""
-        return urljoin(cls.auth_url, path)
-
-    @classmethod
-    def get_training_uri(cls, path: str) -> str:
-        """Get PFT URI."""
-        return urljoin(cls.training_url, path)
-
-    @classmethod
-    def get_training_ws_uri(cls, path: str) -> str:
-        """Get PFT websocket URI."""
-        return urljoin(cls.training_ws_url, path)
-
-    @classmethod
-    def get_serving_uri(cls, path: str) -> str:
-        """Get PFS URI."""
-        return urljoin(cls.serving_url, path)
-
-    @classmethod
-    def get_mr_uri(cls, path: str) -> str:
-        """Get PFR URI."""
-        return urljoin(cls.registry_url, path)
-
-    @classmethod
-    def get_meter_uri(cls, path: str) -> str:
-        """Get PFM URI."""
-        return urljoin(cls.meter_url, path)
-
-    @classmethod
-    def get_observatory_uri(cls, path: str) -> str:
-        """Get PFO URI."""
-        return urljoin(cls.observatory_url, path)
-
 
 class StagingURLProvider(URLProvider):
     """Staging service URL provider."""
@@ -114,41 +87,6 @@ class StagingURLProvider(URLProvider):
     meter_url = "https://pfmeter-staging.friendli.ai/"
     observatory_url = "https://pfo-staging.friendli.ai/"
 
-    @classmethod
-    def get_auth_uri(cls, path: str) -> str:
-        """Get PFA URI."""
-        return urljoin(cls.auth_url, path)
-
-    @classmethod
-    def get_training_uri(cls, path: str) -> str:
-        """Get PFT URI."""
-        return urljoin(cls.training_url, path)
-
-    @classmethod
-    def get_training_ws_uri(cls, path: str) -> str:
-        """Get PFT websocket URI."""
-        return urljoin(cls.training_ws_url, path)
-
-    @classmethod
-    def get_serving_uri(cls, path: str) -> str:
-        """Get PFS URI."""
-        return urljoin(cls.serving_url, path)
-
-    @classmethod
-    def get_mr_uri(cls, path: str) -> str:
-        """Get PFR URI."""
-        return urljoin(cls.registry_url, path)
-
-    @classmethod
-    def get_meter_uri(cls, path: str) -> str:
-        """Get PFM URI."""
-        return urljoin(cls.meter_url, path)
-
-    @classmethod
-    def get_observatory_uri(cls, path: str) -> str:
-        """Get PFO URI."""
-        return urljoin(cls.observatory_url, path)
-
 
 class DevURLProvider(URLProvider):
     """Dev service URL provider."""
@@ -160,38 +98,3 @@ class DevURLProvider(URLProvider):
     auth_url = "https://pfauth-dev.friendli.ai/"
     meter_url = "https://pfmeter-dev.friendli.ai/"
     observatory_url = "https://pfo-dev.friendli.ai/"
-
-    @classmethod
-    def get_auth_uri(cls, path: str) -> str:
-        """Get PFA URI."""
-        return urljoin(cls.auth_url, path)
-
-    @classmethod
-    def get_training_uri(cls, path: str) -> str:
-        """Get PFT URI."""
-        return urljoin(cls.training_url, path)
-
-    @classmethod
-    def get_training_ws_uri(cls, path: str) -> str:
-        """Get PFT websocket URI."""
-        return urljoin(cls.training_ws_url, path)
-
-    @classmethod
-    def get_serving_uri(cls, path: str) -> str:
-        """Get PFS URI."""
-        return urljoin(cls.serving_url, path)
-
-    @classmethod
-    def get_mr_uri(cls, path: str) -> str:
-        """Get PFR URI."""
-        return urljoin(cls.registry_url, path)
-
-    @classmethod
-    def get_meter_uri(cls, path: str) -> str:
-        """Get PFM URI."""
-        return urljoin(cls.meter_url, path)
-
-    @classmethod
-    def get_observatory_uri(cls, path: str) -> str:
-        """Get PFO URI."""
-        return urljoin(cls.observatory_url, path)

--- a/periflow/utils/version.py
+++ b/periflow/utils/version.py
@@ -23,7 +23,7 @@ def is_latest_version(ver: str) -> bool:
     version = parse_version(ver)
     latest_version = get_latest_version()
 
-    return version == latest_version
+    return version >= latest_version
 
 
 def get_latest_version() -> _BaseVersion:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1595,6 +1595,23 @@ files = [
 ]
 
 [[package]]
+name = "injector"
+version = "0.21.0"
+description = "Injector - Python dependency injection framework, inspired by Guice"
+optional = false
+python-versions = "*"
+files = [
+    {file = "injector-0.21.0-py2.py3-none-any.whl", hash = "sha256:3942c5e4c501d390d5ad1b8d7d486ef93b844934afeeb17211acb6c4ca29eeb4"},
+    {file = "injector-0.21.0.tar.gz", hash = "sha256:919eb6b9f96f40bf98fda34c79762b217bd1544d9adc35805ff2948e92356c9c"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.9\""}
+
+[package.extras]
+dev = ["black (==23.3.0)", "build (==0.10.0)", "check-manifest (==0.49)", "click (==8.1.3)", "coverage (==7.2.7)", "exceptiongroup (==1.1.1)", "iniconfig (==2.0.0)", "mypy (==1.4.1)", "mypy-extensions (==1.0.0)", "packaging (==23.1)", "pathspec (==0.11.1)", "platformdirs (==3.8.0)", "pluggy (==1.2.0)", "pyproject-hooks (==1.0.0)", "pytest (==7.4.0)", "pytest-cov (==4.1.0)", "tomli (==2.0.1)", "typing-extensions (==4.7.0)"]
+
+[[package]]
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -3547,4 +3564,4 @@ mllib = ["accelerate", "einops", "h5py", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "1f442b38e3f5498614b6727551c5a318c9a8ba6e79b68e0b83da23b7fb65c906"
+content-hash = "1235051379266af3961c96650b9095a7ea3d196c147066a4780654ad61043776"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "periflow-client"
-version = "0.1.5"
+version = "0.1.6"
 description = "Client of PeriFlow, the fastest generative AI serving available."
 license = "Apache-2.0"
 authors = ["PeriFlow teams <eng@friendli.ai>"]
@@ -8,7 +8,7 @@ packages = [
     { include = "periflow" },
 ]
 readme = "README.md"
-homepage = "https://docs.periflow.ai/"
+homepage = "https://friendli.ai/periflow"
 repository = "https://github.com/friendliai/periflow-client"
 documentation = "https://docs.periflow.ai/"
 keywords = ["generative-ai", "serving", "llm"]
@@ -49,6 +49,7 @@ transformers = { version = "^4.31.0", optional = true }
 h5py = { version = "3.9.0", optional = true }
 einops = { version = "0.6.1", optional = true }
 accelerate = { version = "^0.21.0", optional = true }
+injector = "0.21.0"
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -9,13 +9,16 @@ import pytest
 import requests_mock
 
 import periflow
-from periflow.utils.url import get_training_uri
+from periflow.di.injector import get_injector
+from periflow.utils.url import URLProvider
 
 
 @pytest.fixture
 def patch_auto_token_refresh(requests_mock: requests_mock.Mocker):
     periflow.api_key = "fake-api-key"
-    requests_mock.post(get_training_uri("token/refresh"))
+    injector = get_injector()
+    url_provider = injector.get(URLProvider)
+    requests_mock.post(url_provider.get_training_uri("token/refresh"))
 
 
 @pytest.fixture


### PR DESCRIPTION
# PR Description

## Summary

This PR introduces DI(dependency injection) system to the package. It makes the `Client` modules have loose binding to service URLs. That is, we can easily switch the service URL endpoints to dev, staging, production, etc.

## Motivation and Context

For writing E2E tests, we need an easy way to switch the service URL to the dev or staging server.

## Dependencies

Python [injector](https://github.com/python-injector/injector) package is used for this change.

## Type of Change

- New feature
